### PR TITLE
Added check for GCC internals for unsorted tests

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,8 @@
+2021-04-29  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* gcc.c-torture/unsorted/dump-noaddr.x: Added check for GCC internals
+	which is required to produce the dump files.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.c-torture/unsorted/dump-noaddr.x
+++ b/gcc/testsuite/gcc.c-torture/unsorted/dump-noaddr.x
@@ -33,5 +33,8 @@ proc dump_compare { src options } {
     file delete -force $tmpdir/dump2
 }
 
-dump_compare $src $options
+if { [check_effective_target_gcc_internals] } {
+  dump_compare $src $options
+}
+
 return 1


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

        * gcc.c-torture/unsorted/dump-noaddr.x: Added check for GCC internals
        which is required to produce the dump files.