### PR TITLE
Added a proc template to check for optimisation flag support

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,71 @@
+2021-04-29  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* lib/target-supports-dg.exp (dg-require-effective-target-flag): Added
+	a proc template to check whether or not an optimisation flag is
+	supported by the target.
+	* lib/target-supports.exp (is-effective-target-flag): Likewise.
+	* gcc.dg/iec-559-macros-6.c: Requires target with support for
+	optimisation flags.
+	* gcc.dg/independent-cloneids-1.c: Likewise.
+	* gcc.dg/nested-func-12.c: Likewise.
+	* gcc.dg/pr49860.c: Likewise.
+	* gcc.dg/pr51039.c: Likewise.
+	* gcc.dg/pr87929.c: Likewise.
+	* gcc.dg/pr88444.c: Likewise.
+	* gcc.dg/pr92591-2.c: Likewise.
+	* gcc.dg/pr94002.c: Likewise.
+	* gcc.dg/pr94292.c: Likewise.
+	* gcc.dg/pr95580.c: Likewise.
+	* gcc.dg/pr97192.c: Likewise.
+	* gcc.dg/pr97396.c: Likewise.
+	* gcc.dg/single-precision-constant.c: Likewise.
+	* gcc.dg/sms-compare-debug-1.c: Likewise.
+	* gcc.dg/type-convert-var.c: Likewise.
+	* gcc.dg/var-expand2.c: Likewise.
+	* gcc.dg/cpp/Wunused.c: Requires target with support for the
+	optimisation flag "-fuse-linker-plugin".
+	* gcc.dg/cpp/builtin-macro-1.c: Likewise.
+	* gcc.dg/cpp/c11-scope-1.c: Likewise.
+	* gcc.dg/cpp/c17-scope-1.c: Likewise.
+	* gcc.dg/cpp/c2x-scope-1.c: Likewise.
+	* gcc.dg/cpp/c2x-scope-2.c: Likewise.
+	* gcc.dg/cpp/c90-scope-1.c: Likewise.
+	* gcc.dg/cpp/c94-scope-1.c: Likewise.
+	* gcc.dg/cpp/c99-scope-1.c: Likewise.
+	* gcc.dg/cpp/charconst-3.c: Likewise.
+	* gcc.dg/cpp/cxxcom2.c: Likewise.
+	* gcc.dg/cpp/gnu11-scope-1.c: Likewise.
+	* gcc.dg/cpp/gnu17-scope-1.c: Likewise.
+	* gcc.dg/cpp/gnu89-scope-1.c: Likewise.
+	* gcc.dg/cpp/gnu99-scope-1.c: Likewise.
+	* gcc.dg/cpp/line10.c: Likewise.
+	* gcc.dg/cpp/line11.c: Likewise.
+	* gcc.dg/cpp/line12.c: Likewise.
+	* gcc.dg/cpp/line9.c: Likewise.
+	* gcc.dg/cpp/mi1.c: Likewise.
+	* gcc.dg/cpp/mi6.c: Likewise.
+	* gcc.dg/cpp/paste16.c: Likewise.
+	* gcc.dg/cpp/pr20356.c: Likewise.
+	* gcc.dg/cpp/pr23827_c90.c: Likewise.
+	* gcc.dg/cpp/pr61854-5.c: Likewise.
+	* gcc.dg/cpp/pr61854-7.c: Likewise.
+	* gcc.dg/cpp/pr71681-1.c: Likewise.
+	* gcc.dg/cpp/pr71681-2.c: Likewise.
+	* gcc.dg/cpp/pr97989-2.c: Likewise.
+	* gcc.dg/cpp/pr98882.c: Likewise.
+	* gcc.dg/cpp/redef4.c: Likewise.
+	* gcc.dg/cpp/strify5.c: Likewise.
+	* gcc.dg/cpp/ucnid-11-utf8.c: Likewise.
+	* gcc.dg/cpp/ucnid-13-utf8.c: Likewise.
+	* gcc.dg/cpp/ucnid-4-utf8.c: Likewise.
+	* gcc.dg/cpp/ucnid-6-utf8.c: Likewise.
+	* gcc.dg/cpp/ucnid-7-utf8.c: Likewise.
+	* gcc.dg/cpp/unc1.c: Likewise.
+	* gcc.dg/cpp/unc2.c: Likewise.
+	* gcc.dg/cpp/utf8-5byte-1.c: Likewise.
+	* gcc.dg/cpp/vararg3.c: Likewise.
+	* gcc.dg/cpp/vararg4.c: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.dg/cpp/Wunused.c
+++ b/gcc/testsuite/gcc.dg/cpp/Wunused.c
@@ -3,6 +3,7 @@
 /* { dg-do preprocess } */
 /* Duplicate command line options should not warn.  */
 /* { dg-options "-Wunused-macros -Dfoo -Dfoo" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* Test everything related to -Wunused-macros.
 

--- a/gcc/testsuite/gcc.dg/cpp/builtin-macro-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/builtin-macro-1.c
@@ -5,7 +5,8 @@
    the function-like macro expansion it's part of.
 
    { dg-do run }
-   { do-options -no-integrated-cpp }  */
+   { do-options -no-integrated-cpp }
+   { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #include <assert.h>
 

--- a/gcc/testsuite/gcc.dg/cpp/c11-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c11-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token not in C11.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c11 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/c17-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c17-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token not in C17.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c17 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/c2x-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c2x-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token in C2x.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c2x -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/c2x-scope-2.c
+++ b/gcc/testsuite/gcc.dg/cpp/c2x-scope-2.c
@@ -1,6 +1,7 @@
 /* Test :: token in C2x: preprocessed output.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c2x -pedantic-errors -P" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define COLON() :
 #define TEST() ABC

--- a/gcc/testsuite/gcc.dg/cpp/c90-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c90-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token not in C90.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c90 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/c94-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c94-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token not in C94.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=iso9899:199409 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/c99-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/c99-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token not in C99.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c99 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/charconst-3.c
+++ b/gcc/testsuite/gcc.dg/cpp/charconst-3.c
@@ -2,6 +2,7 @@
 
 /* { dg-do run } */
 /* { dg-options -Wno-multichar } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* This tests values and signedness of multichar charconsts.
 

--- a/gcc/testsuite/gcc.dg/cpp/cxxcom2.c
+++ b/gcc/testsuite/gcc.dg/cpp/cxxcom2.c
@@ -1,5 +1,6 @@
 /* { dg-do preprocess } */
 /* { dg-options "-pedantic -std=c89 -Wall" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #include "cxxcom2.h"
 

--- a/gcc/testsuite/gcc.dg/cpp/gnu11-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/gnu11-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token in gnu11.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=gnu11 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/gnu17-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/gnu17-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token in gnu17.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=gnu17 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/gnu89-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/gnu89-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token in gnu89.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=gnu89 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/gnu99-scope-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/gnu99-scope-1.c
@@ -1,6 +1,7 @@
 /* Test :: token in gnu99.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=gnu99 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define CONCAT(x, y) x ## y
 

--- a/gcc/testsuite/gcc.dg/cpp/line10.c
+++ b/gcc/testsuite/gcc.dg/cpp/line10.c
@@ -1,5 +1,6 @@
 /* Test #line overflow checks: bug 97602.  */
 /* { dg-do preprocess } */
 /* { dg-options "-pedantic" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #line 4294967296 /* { dg-warning "line number out of range" } */

--- a/gcc/testsuite/gcc.dg/cpp/line11.c
+++ b/gcc/testsuite/gcc.dg/cpp/line11.c
@@ -1,6 +1,7 @@
 /* PR c/99325 */
 /* { dg-do preprocess } */
 /* { dg-options "-pedantic" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #line 4294967295	/* { dg-warning "line number out of range" } */
 #pragma message "foo"

--- a/gcc/testsuite/gcc.dg/cpp/line12.c
+++ b/gcc/testsuite/gcc.dg/cpp/line12.c
@@ -1,6 +1,7 @@
 /* PR c/99325 */
 /* { dg-do preprocess } */
 /* { dg-options "-pedantic" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #line 9223372036854775807	/* { dg-warning "line number out of range" } */
 #pragma message "foo"

--- a/gcc/testsuite/gcc.dg/cpp/line9.c
+++ b/gcc/testsuite/gcc.dg/cpp/line9.c
@@ -1,5 +1,6 @@
 /* Test #line overflow checks: bug 97602.  */
 /* { dg-do preprocess } */
 /* { dg-options "-pedantic" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #line 5000000000 /* { dg-warning "line number out of range" } */

--- a/gcc/testsuite/gcc.dg/cpp/mi1.c
+++ b/gcc/testsuite/gcc.dg/cpp/mi1.c
@@ -13,7 +13,8 @@
 
 /* { dg-do compile }
    { dg-options "-H" }
-   { dg-message "mi1c\.h\n\[^\n\]*mi1cc\.h\n\[^\n\]*mi1nd\.h\n\[^\n\]*mi1ndp\.h\n\[^\n\]*mi1x\.h" "redundant include check" { target *-*-* } 0 } */
+   { dg-message "mi1c\.h\n\[^\n\]*mi1cc\.h\n\[^\n\]*mi1nd\.h\n\[^\n\]*mi1ndp\.h\n\[^\n\]*mi1x\.h" "redundant include check" { target *-*-* } 0 }
+   { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #include "mi1c.h"
 #include "mi1c.h"

--- a/gcc/testsuite/gcc.dg/cpp/mi6.c
+++ b/gcc/testsuite/gcc.dg/cpp/mi6.c
@@ -4,6 +4,7 @@
 
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 extern void abort (void);
 

--- a/gcc/testsuite/gcc.dg/cpp/paste16.c
+++ b/gcc/testsuite/gcc.dg/cpp/paste16.c
@@ -1,6 +1,7 @@
 /* Test multiple consecutive ## tokens.  */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 #define cat(x,y) x##########y
 int abcd;
 int *p = &cat(ab,cd);

--- a/gcc/testsuite/gcc.dg/cpp/pr20356.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr20356.c
@@ -1,6 +1,7 @@
 /* PR preprocessor/20356 */
 /* { dg-do compile } */
 /* { dg-options "-I$srcdir/gcc.dg/cpp -I$srcdir/gcc.dg/cpp/inc" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #include <pr20356-aux.h>
 

--- a/gcc/testsuite/gcc.dg/cpp/pr23827_c90.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr23827_c90.c
@@ -1,5 +1,6 @@
 /* { dg-do run }  */
 /* { dg-options "-std=c90 -pedantic-errors" }  */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define f (
 #define l )

--- a/gcc/testsuite/gcc.dg/cpp/pr61854-5.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr61854-5.c
@@ -1,6 +1,7 @@
 /* PR c/61854 */
 /* { dg-do run } */
 /* { dg-options "-std=c89" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define h(x) #x
 #define s(x) h(x)

--- a/gcc/testsuite/gcc.dg/cpp/pr61854-7.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr61854-7.c
@@ -1,6 +1,7 @@
 /* PR c/61854 */
 /* { dg-do run } */
 /* { dg-options "-std=c89" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 int
 main (void)

--- a/gcc/testsuite/gcc.dg/cpp/pr71681-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr71681-1.c
@@ -2,5 +2,6 @@
 // { dg-do preprocess }
 // { dg-options "-remap -I$srcdir/gcc.dg/cpp/remap" }
 // { dg-additional-options "-Wno-unused-command-line-argument" }
+// { dg-require-effective-target-flag { -fuse-linker-plugin } }
 
 #include "a/t1.h"

--- a/gcc/testsuite/gcc.dg/cpp/pr71681-2.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr71681-2.c
@@ -2,5 +2,6 @@
 // { dg-do preprocess }
 // { dg-options "-remap -I$srcdir/gcc.dg/cpp/remap" }
 // { dg-additional-options "-Wno-unused-command-line-argument" }
+// { dg-require-effective-target-flag { -fuse-linker-plugin } }
 
 #include "a/t2.h"

--- a/gcc/testsuite/gcc.dg/cpp/pr97989-2.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr97989-2.c
@@ -1,6 +1,7 @@
 /* PR debug/97989 */
 /* { dg-do preprocess } */
 /* { dg-options "-g2 -g3 -P" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define foo bar
 int i;

--- a/gcc/testsuite/gcc.dg/cpp/pr98882.c
+++ b/gcc/testsuite/gcc.dg/cpp/pr98882.c
@@ -1,6 +1,7 @@
 /* PR preprocessor/98882 */
 /* { dg-do preprocess } */
 /* { dg-options "-fdirectives-only" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* Last line does not end with a newline.  */
     /*Here*/

--- a/gcc/testsuite/gcc.dg/cpp/redef4.c
+++ b/gcc/testsuite/gcc.dg/cpp/redef4.c
@@ -3,6 +3,7 @@
    consecutive paste tokens.  */
 /* { dg-do preprocess } */
 /* { dg-options "" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #define str(x) #x /* { dg-message "-:previous definition" } */
 #define str(x) %: x /* { dg-warning "-:redefined" } */

--- a/gcc/testsuite/gcc.dg/cpp/strify5.c
+++ b/gcc/testsuite/gcc.dg/cpp/strify5.c
@@ -1,6 +1,7 @@
 /* Test handling of spaces and empty macro expansions in
    stringifying.  PR 31869.  */
 /* { dg-do run } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 extern int strcmp (const char *, const char *);
 extern int puts (const char *);

--- a/gcc/testsuite/gcc.dg/cpp/ucnid-11-utf8.c
+++ b/gcc/testsuite/gcc.dg/cpp/ucnid-11-utf8.c
@@ -2,6 +2,7 @@
    redefinitions.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c99 -pedantic-errors" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* Different spelling of UCN in expansion.  */
 #define m1 \u00c1 /* { dg-message "-:previous definition" } */

--- a/gcc/testsuite/gcc.dg/cpp/ucnid-13-utf8.c
+++ b/gcc/testsuite/gcc.dg/cpp/ucnid-13-utf8.c
@@ -1,5 +1,6 @@
 /* Verify macros named with UTF-8 are output in -dD output with UCNs.  */
 /* { dg-do preprocess } */
 /* { dg-options "-std=c99 -dD" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 /* { dg-final { scan-file ucnid-13-utf8.i "\\\\U000000c1" } } */
 #define Á 1

--- a/gcc/testsuite/gcc.dg/cpp/ucnid-4-utf8.c
+++ b/gcc/testsuite/gcc.dg/cpp/ucnid-4-utf8.c
@@ -1,5 +1,6 @@
 /* { dg-do preprocess } */
 /* { dg-options "-std=c99" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 ª
 « /* not a preprocessing error because we lex it into its own token */

--- a/gcc/testsuite/gcc.dg/cpp/ucnid-6-utf8.c
+++ b/gcc/testsuite/gcc.dg/cpp/ucnid-6-utf8.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-std=c89" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 #define a b(
 #define b(x) q
 int aª);

--- a/gcc/testsuite/gcc.dg/cpp/ucnid-7-utf8.c
+++ b/gcc/testsuite/gcc.dg/cpp/ucnid-7-utf8.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-std=c99" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* When GCC reads UTF-8-encoded input into its internal UTF-8
 representation, it does not apply any transformation to the data, and

--- a/gcc/testsuite/gcc.dg/cpp/unc1.c
+++ b/gcc/testsuite/gcc.dg/cpp/unc1.c
@@ -1,5 +1,6 @@
 /* Tests for un-terminated conditionals: 1.  */
 /* { dg-do preprocess } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #if 1  /* { dg-error "-:unterminated" "unterminated #if" } */
 

--- a/gcc/testsuite/gcc.dg/cpp/unc2.c
+++ b/gcc/testsuite/gcc.dg/cpp/unc2.c
@@ -1,5 +1,6 @@
 /* Tests for unterminated conditionals: 2.  */
 /* { dg-do preprocess } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 #ifdef __sparc__  /* { dg-error "-:unterminated" "unterminated if-elif-elif..." } */
 sparc

--- a/gcc/testsuite/gcc.dg/cpp/utf8-5byte-1.c
+++ b/gcc/testsuite/gcc.dg/cpp/utf8-5byte-1.c
@@ -2,6 +2,7 @@
    cpplib.  */
 /* { dg-do run { target { 4byte_wchar_t } } } */
 /* { dg-options "-std=gnu99 -w" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 extern void abort (void);
 extern void exit (int);

--- a/gcc/testsuite/gcc.dg/cpp/vararg3.c
+++ b/gcc/testsuite/gcc.dg/cpp/vararg3.c
@@ -2,6 +2,7 @@
 
 /* { dg-do preprocess } */
 /* { dg-options "-std=c99" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* Source: Neil Booth, 6 Aug 2002.
 

--- a/gcc/testsuite/gcc.dg/cpp/vararg4.c
+++ b/gcc/testsuite/gcc.dg/cpp/vararg4.c
@@ -2,6 +2,7 @@
 
 /* { dg-do preprocess } */
 /* { dg-options -std=gnu99 } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
 
 /* Source: Neil Booth, 6 Aug 2002.
 

--- a/gcc/testsuite/gcc.dg/iec-559-macros-6.c
+++ b/gcc/testsuite/gcc.dg/iec-559-macros-6.c
@@ -1,6 +1,7 @@
 /* Test __GCC_IEC_559 and __GCC_IEC_559_COMPLEX macros values.  */
 /* { dg-do preprocess } */
 /* { dg-options "-fsingle-precision-constant" } */
+/* { dg-require-effective-target-flag { -fsingle-precision-constant } } */
 
 #ifndef __GCC_IEC_559
 # error "__GCC_IEC_559 not defined"

--- a/gcc/testsuite/gcc.dg/independent-cloneids-1.c
+++ b/gcc/testsuite/gcc.dg/independent-cloneids-1.c
@@ -1,6 +1,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O3 -fipa-cp -fipa-cp-clone -fdump-rtl-final"  } */
 /* { dg-skip-if "Odd label definition syntax" { mmix-*-* } } */
+/* { dg-require-effective-target-flag { -fipa-cp-clone -fdump-rtl-final -fipa-cp } } */
 
 extern int printf (const char *, ...);
 

--- a/gcc/testsuite/gcc.dg/nested-func-12.c
+++ b/gcc/testsuite/gcc.dg/nested-func-12.c
@@ -2,6 +2,7 @@
 /* { dg-do run } */
 /* { dg-options "-Ofast --param ipa-cp-eval-threshold=0 -fno-guess-branch-probability -fno-inline-small-functions" } */
 /* { dg-require-effective-target alloca } */
+/* { dg-require-effective-target-flag { -fno-inline-small-functions -fno-guess-branch-probability } } */
 
 void
 foo (int n)

--- a/gcc/testsuite/gcc.dg/pr49860.c
+++ b/gcc/testsuite/gcc.dg/pr49860.c
@@ -1,5 +1,6 @@
 /* { dg-do assemble } */
 /* { dg-options "-O3 -funroll-all-loops" } */
+/* { dg-require-effective-target-flag { -funroll-all-loops } } */
 
 extern char inbuf[];
 extern char outbuf[];

--- a/gcc/testsuite/gcc.dg/pr51039.c
+++ b/gcc/testsuite/gcc.dg/pr51039.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O -finline-small-functions -fno-ipa-pure-const" } */
+/* { dg-require-effective-target-flag { -finline-small-functions -fno-ipa-pure-const } } */
 
 float baz (void)
 {

--- a/gcc/testsuite/gcc.dg/pr87929.c
+++ b/gcc/testsuite/gcc.dg/pr87929.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-fexceptions -fnon-call-exceptions -fsignaling-nans" } */
+/* { dg-require-effective-target-flag { -fsignaling-nans } } */
 
 #define complex __complex__
 #define _Complex_I (1.0iF)

--- a/gcc/testsuite/gcc.dg/pr88444.c
+++ b/gcc/testsuite/gcc.dg/pr88444.c
@@ -1,6 +1,7 @@
 /* PR tree-optimization/88444 */
 /* { dg-do compile } */
 /* { dg-options "-O1 -ftree-vrp -fno-tree-ccp -fno-tree-forwprop -fno-tree-fre" } */
+/* { dg-require-effective-target-flag { -ftree-vrp -fno-tree-ccp -fno-tree-forwprop -fno-tree-fre } } */
 
 int v;
 

--- a/gcc/testsuite/gcc.dg/pr92591-2.c
+++ b/gcc/testsuite/gcc.dg/pr92591-2.c
@@ -1,5 +1,6 @@
 /* PR rtl-optimization/92591 */
 /* { dg-do compile } */
 /* { dg-options "-Os -fmodulo-sched -fmodulo-sched-allow-regmoves --param sms-dfa-history=8" } */
+/* { dg-require-effective-target-flag { -fmodulo-sched -fmodulo-sched-allow-regmoves } } */
 
 #include "../gcc.c-torture/execute/pr61682.c"

--- a/gcc/testsuite/gcc.dg/pr94002.c
+++ b/gcc/testsuite/gcc.dg/pr94002.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -fno-tree-dce -fno-tree-reassoc" } */
 /* { dg-additional-options "-fPIC" { target fpic } } */
+/* { dg-require-effective-target-flag { -fno-tree-reassoc -fno-tree-dce } } */
 
 unsigned a, b;
 

--- a/gcc/testsuite/gcc.dg/pr94292.c
+++ b/gcc/testsuite/gcc.dg/pr94292.c
@@ -1,6 +1,7 @@
 /* PR target/94292 */
 /* { dg-do compile } */
 /* { dg-options "-O1 -g -fno-tree-dce" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce } } */
 
 unsigned short a;
 unsigned long long b;

--- a/gcc/testsuite/gcc.dg/pr95580.c
+++ b/gcc/testsuite/gcc.dg/pr95580.c
@@ -1,6 +1,7 @@
 /* PR c/95580 */
 /* { dg-do compile } */
 /* { dg-options "-O1 -W -fno-tree-dce" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce } } */
 
 void bar (void);
 

--- a/gcc/testsuite/gcc.dg/pr97192.c
+++ b/gcc/testsuite/gcc.dg/pr97192.c
@@ -1,6 +1,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O -ftracer" } */
 /* { dg-additional-options "-mavx512vl" { target x86_64-*-* i?86-*-* } } */
+/* { dg-require-effective-target-flag { -ftracer } } */
 
 typedef int __attribute__ ((__vector_size__ (32))) V;
 

--- a/gcc/testsuite/gcc.dg/pr97396.c
+++ b/gcc/testsuite/gcc.dg/pr97396.c
@@ -1,6 +1,7 @@
 // { dg-do compile }
 // { dg-options "-O1 -ftree-vrp" }
 // { dg-additional-options "-m32" { target { i?86-*-* x86_64-*-* } } }
+// { dg-require-effective-target-flag { -ftree-vrp } }
 
 unsigned int
 po (char *os, unsigned int al)

--- a/gcc/testsuite/gcc.dg/single-precision-constant.c
+++ b/gcc/testsuite/gcc.dg/single-precision-constant.c
@@ -4,6 +4,7 @@
 
 /* { dg-do run } */
 /* { dg-options "-fsingle-precision-constant" } */
+/* { dg-require-effective-target-flag { -fsingle-precision-constant } } */
 
 #include <math.h>
 #include <float.h>

--- a/gcc/testsuite/gcc.dg/sms-compare-debug-1.c
+++ b/gcc/testsuite/gcc.dg/sms-compare-debug-1.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -fcompare-debug -fmodulo-sched --param sms-min-sc=1" } */
+/* { dg-require-effective-target-flag { -fmodulo-sched -fcompare-debug } } */
 
 int a, c, e, f, g;
 void

--- a/gcc/testsuite/gcc.dg/type-convert-var.c
+++ b/gcc/testsuite/gcc.dg/type-convert-var.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-additional-options "-fexcess-precision=fast -O1 -fdump-tree-optimized" } */
+/* { dg-require-effective-target-flag { -fdump-tree-optimized -fexcess-precision=fast } } */
 void foo (float a, float b, float *c)
 {
   double e = (double)a * (double)b;

--- a/gcc/testsuite/gcc.dg/var-expand2.c
+++ b/gcc/testsuite/gcc.dg/var-expand2.c
@@ -1,5 +1,6 @@
 /* { dg-do run } */
 /* { dg-options "-O2 -funroll-loops -ffast-math -fvariable-expansion-in-unroller" } */
+/* { dg-require-effective-target-flag { -fvariable-expansion-in-unroller } } */
 
 extern void abort (void);
 

--- a/gcc/testsuite/lib/target-supports-dg.exp
+++ b/gcc/testsuite/lib/target-supports-dg.exp
@@ -243,6 +243,37 @@ proc dg-require-effective-target { args } {
     }
 }
 
+# If the target does not support the specified flag, skip this test.
+# Only apply this if the optional selector matches.
+# args[0] flag to test for
+# args[1] optional selector
+
+proc dg-require-effective-target-flag { args } {
+    set args [lreplace $args 0 0]
+    # Verify the number of arguments.  The last is optional.
+    if { [llength $args] < 1 || [llength $args] > 2 } {
+    error "syntax error, need a single effective-target flag with optional selector"
+    }
+
+    # Don't bother if we're already skipping the test.
+    upvar dg-do-what dg-do-what
+    if { [lindex ${dg-do-what} 1] == "N" } {
+      return
+    }
+
+    # Evaluate selector if present.
+    if { [llength $args] == 2 } {
+    switch [dg-process-target-1 [lindex $args 1]] {
+        "S" { }
+        "N" { return }
+    }
+    }
+
+    if { ![is-effective-target-flag [lindex $args 0]] } {
+        set dg-do-what [list [lindex ${dg-do-what} 0] "N" "P"]
+    }
+}
+
 # If this target does not have fork, skip this test.
 
 proc dg-require-fork { args } {

--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -8179,6 +8179,27 @@ proc is-effective-target { arg } {
     return $selected
 }
 
+# Return 1 if the effective target supports the specified flag
+# This can be used with any check_flag_* proc that takes no argument and
+# returns only 1 or 0.
+# arg[0] the flag to check for.
+
+proc is-effective-target-flag { arg } {
+    set selected 0
+
+    set selected [check_no_compiler_messages optimisation_flag assembly "
+        int main (void) { return 0; }
+    " "$arg"]
+    if { !$selected } {
+      return 0
+    } else {
+      return 1
+    }
+
+    verbose "is-effective-target-flag: $arg $selected" 2
+    return selected
+}
+
 # Return 1 if the argument is an effective-target keyword, 0 otherwise.
 
 proc is-effective-target-keyword { arg } {
@@ -11402,4 +11423,3 @@ proc check_effective_target_invalid_inline_asm { } {
 	void foo (void) { asm ("This is invalid"); }
     }]
 }
-


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

            * lib/target-supports-dg.exp (dg-require-effective-target-flag): Added
            a proc template to check whether or not an optimisation flag is
            supported by the target.
            * lib/target-supports.exp (is-effective-target-flag): Likewise.
            * gcc.dg/iec-559-macros-6.c: Requires target with support for
            optimisation flags.
            * gcc.dg/independent-cloneids-1.c: Likewise.
            * gcc.dg/nested-func-12.c: Likewise.
            * gcc.dg/pr49860.c: Likewise.
            * gcc.dg/pr51039.c: Likewise.
            * gcc.dg/pr87929.c: Likewise.
            * gcc.dg/pr88444.c: Likewise.
            * gcc.dg/pr92591-2.c: Likewise.
            * gcc.dg/pr94002.c: Likewise.
            * gcc.dg/pr94292.c: Likewise.
            * gcc.dg/pr95580.c: Likewise.
            * gcc.dg/pr97192.c: Likewise.
            * gcc.dg/pr97396.c: Likewise.
            * gcc.dg/single-precision-constant.c: Likewise.
            * gcc.dg/sms-compare-debug-1.c: Likewise.
            * gcc.dg/type-convert-var.c: Likewise.
            * gcc.dg/var-expand2.c: Likewise.
            * gcc.dg/cpp/Wunused.c: Requires target with support for the
            optimisation flag "-fuse-linker-plugin".
            * gcc.dg/cpp/builtin-macro-1.c: Likewise.
            * gcc.dg/cpp/c11-scope-1.c: Likewise.
            * gcc.dg/cpp/c17-scope-1.c: Likewise.
            * gcc.dg/cpp/c2x-scope-1.c: Likewise.
            * gcc.dg/cpp/c2x-scope-2.c: Likewise.
            * gcc.dg/cpp/c90-scope-1.c: Likewise.
            * gcc.dg/cpp/c94-scope-1.c: Likewise.
            * gcc.dg/cpp/c99-scope-1.c: Likewise.
            * gcc.dg/cpp/charconst-3.c: Likewise.
            * gcc.dg/cpp/cxxcom2.c: Likewise.
            * gcc.dg/cpp/gnu11-scope-1.c: Likewise.
            * gcc.dg/cpp/gnu17-scope-1.c: Likewise.
            * gcc.dg/cpp/gnu89-scope-1.c: Likewise.
            * gcc.dg/cpp/gnu99-scope-1.c: Likewise.
            * gcc.dg/cpp/line10.c: Likewise.
            * gcc.dg/cpp/line11.c: Likewise.
            * gcc.dg/cpp/line12.c: Likewise.
            * gcc.dg/cpp/line9.c: Likewise.
            * gcc.dg/cpp/mi1.c: Likewise.
            * gcc.dg/cpp/mi6.c: Likewise.
            * gcc.dg/cpp/paste16.c: Likewise.
            * gcc.dg/cpp/pr20356.c: Likewise.
            * gcc.dg/cpp/pr23827_c90.c: Likewise.
            * gcc.dg/cpp/pr61854-5.c: Likewise.
            * gcc.dg/cpp/pr61854-7.c: Likewise.
            * gcc.dg/cpp/pr71681-1.c: Likewise.
            * gcc.dg/cpp/pr71681-2.c: Likewise.
            * gcc.dg/cpp/pr97989-2.c: Likewise.
            * gcc.dg/cpp/pr98882.c: Likewise.
            * gcc.dg/cpp/redef4.c: Likewise.
            * gcc.dg/cpp/strify5.c: Likewise.
            * gcc.dg/cpp/ucnid-11-utf8.c: Likewise.
            * gcc.dg/cpp/ucnid-13-utf8.c: Likewise.
            * gcc.dg/cpp/ucnid-4-utf8.c: Likewise.
            * gcc.dg/cpp/ucnid-6-utf8.c: Likewise.
            * gcc.dg/cpp/ucnid-7-utf8.c: Likewise.
            * gcc.dg/cpp/unc1.c: Likewise.
            * gcc.dg/cpp/unc2.c: Likewise.
            * gcc.dg/cpp/utf8-5byte-1.c: Likewise.
            * gcc.dg/cpp/vararg3.c: Likewise.
            * gcc.dg/cpp/vararg4.c: Likewise.