### PR TITLE
Mark tests as requiring flags unsupported by LLVM/Clang

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,19 @@
+2021-04-29  Pietra Ferreira  <pietra.ferreira@embecosm.com>
+
+	* gcc.c-torture/compile/pr25224.c: Mark test as requiring a specific flag
+	that Clang doesn't support (-funswitch-loops).
+	* gcc.dg/loop-unswitch-4.c: Likewise.
+	* gcc.dg/pr81455.c: Likewise.
+	* gcc.dg/pr84032.c: Mark test as requiring a specific flag that Clang doesn't
+	support (-fmodulo-sched).
+	* gcc.dg/pr88427.c: Mark test as requiring a specific flag that Clang doesn't
+	support (-fno-tree-dce).
+	* gcc.dg/pr94283.c: Likewise.
+	* gcc.dg/pr92115.c: Mark test as requiring a specific flag that Clang doesn't
+	support (-fsignaling-nans).
+	* gcc.dg/pr92591-1.c: Mark test as requiring specific flags that Clang doesn't
+	support (-fmodulo-sched -fweb -fno-ivopts).
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.c-torture/compile/pr25224.c
+++ b/gcc/testsuite/gcc.c-torture/compile/pr25224.c
@@ -1,6 +1,7 @@
 /* { dg-options "-funswitch-loops" } */
 /* { dg-require-effective-target indirect_jumps } */
 /* { dg-require-effective-target label_values } */
+/* { dg-require-effective-target-flag { -funswitch-loops } } */
 
 static float rgam;
 extern void *jmp(void *);

--- a/gcc/testsuite/gcc.dg/loop-unswitch-4.c
+++ b/gcc/testsuite/gcc.dg/loop-unswitch-4.c
@@ -1,5 +1,6 @@
 /* { dg-do run } */
 /* { dg-options "-O2 -funswitch-loops" } */
+/* { dg-require-effective-target-flag { -funswitch-loops } } */
 
 #include <stdlib.h>
 __attribute__ ((noinline))

--- a/gcc/testsuite/gcc.dg/pr81455.c
+++ b/gcc/testsuite/gcc.dg/pr81455.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O -funswitch-loops" } */
+/* { dg-require-effective-target-flag { -funswitch-loops } } */
 
 void
 jh (unsigned int aw, int sn)

--- a/gcc/testsuite/gcc.dg/pr84032.c
+++ b/gcc/testsuite/gcc.dg/pr84032.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -fmodulo-sched" } */
 /* { dg-additional-options "-mcpu=power6" { target { powerpc-*-* } } } */
+/* { dg-require-effective-target-flag { -fmodulo-sched } } */
 
 void
 yr (int cm)

--- a/gcc/testsuite/gcc.dg/pr88427.c
+++ b/gcc/testsuite/gcc.dg/pr88427.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -fno-tree-dce -fno-tree-fre -Wno-div-by-zero" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce } } */
 
 void
 uj (int eq, int s4)

--- a/gcc/testsuite/gcc.dg/pr92115.c
+++ b/gcc/testsuite/gcc.dg/pr92115.c
@@ -1,6 +1,7 @@
 /* PR tree-optimization/92115 */
 /* { dg-do compile } */
 /* { dg-options "-O1 -fexceptions -ffinite-math-only -fnon-call-exceptions -fsignaling-nans -fno-signed-zeros" } */
+/* { dg-require-effective-target-flag { -fsignaling-nans } } */
 
 void
 foo (double x)

--- a/gcc/testsuite/gcc.dg/pr92591-1.c
+++ b/gcc/testsuite/gcc.dg/pr92591-1.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -fmodulo-sched -fweb -fno-dce -fno-ivopts -fno-sched-pressure -fno-tree-loop-distribute-patterns --param sms-dfa-history=1" } */
 /* { dg-additional-options "-mcpu=e500mc" { target { powerpc-*-* } } } */
+/* { dg-require-effective-target-flag { -fmodulo-sched -fweb -fno-ivopts } } */
 
 void
 wf (char *mr, int tc)

--- a/gcc/testsuite/gcc.dg/pr94283.c
+++ b/gcc/testsuite/gcc.dg/pr94283.c
@@ -1,6 +1,7 @@
 /* PR debug/94283 */
 /* { dg-do compile } */
 /* { dg-options "-O3 -fno-tree-dce -fcompare-debug" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce } } */
 
 void
 foo (int *n)


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

	* gcc.c-torture/compile/pr25224.c: Mark test as requiring a specific flag
	that Clang doesn't support (-funswitch-loops).
	* gcc.dg/loop-unswitch-4.c: Likewise.
	* gcc.dg/pr81455.c: Likewise.
	* gcc.dg/pr84032.c: Mark test as requiring a specific flag that Clang doesn't
	support (-fmodulo-sched).
	* gcc.dg/pr88427.c: Mark test as requiring a specific flag that Clang doesn't
	support (-fno-tree-dce).
	* gcc.dg/pr94283.c: Likewise.
	* gcc.dg/pr92115.c: Mark test as requiring a specific flag that Clang doesn't
	support (-fsignaling-nans).
	* gcc.dg/pr92591-1.c: Mark test as requiring specific flags that Clang doesn't
	support (-fmodulo-sched -fweb -fno-ivopts).