### PR TITLE
Mark tests as requiring VLA support

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,8 @@
+2021-05-04  Pietra Ferreira  <pietra.ferreira@embecosm.com>
+
+	* gcc.c-torture/compile/pr77754-6.c: Mark test as requiring VLA support.
+	* gcc.c-torture/compile/pr82564.c: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.c-torture/compile/pr77754-6.c
+++ b/gcc/testsuite/gcc.c-torture/compile/pr77754-6.c
@@ -1,5 +1,6 @@
-// { dg-require-effective-target alloca }
 /* PR c/77754 */
+/* { dg-require-effective-target alloca } */
+/* { dg-require-effective-target vla_in_struct } */
 
 int fn3();
 

--- a/gcc/testsuite/gcc.c-torture/compile/pr82564.c
+++ b/gcc/testsuite/gcc.c-torture/compile/pr82564.c
@@ -1,5 +1,6 @@
 /* PR middle-end/82564 */
 /* { dg-require-effective-target alloca } */
+/* { dg-require-effective-target vla_in_struct } */
 
 int
 main ()


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

	* gcc.c-torture/compile/pr77754-6.c: Mark test as requiring VLA support.
	* gcc.c-torture/compile/pr82564.c: Likewise.