### PR TITLE
Tests marked as requiring vla_in_struct

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,20 @@
+2021-05-04  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* gcc.dg/Warray-bounds-51.c: Marked as requireing
+	vla_in_struct support.
+	* gcc.dg/Wrestrict-17.c: Likewise.
+	* gcc.dg/Wstringop-overflow-39.c: Likewise.
+	* gcc.dg/builtin-clear-padding-1.c: Likewise.
+	* gcc.dg/pr51628-18.c: Likewise.
+	* gcc.dg/pr51628-19.c: Likewise.
+	* gcc.dg/pr93577-1.c: Likewise.
+	* gcc.dg/pr93577-2.c: Likewise.
+	* gcc.dg/pr93577-3.c: Likewise.
+	* gcc.dg/pr93577-4.c: Likewise.
+	* gcc.dg/pr99122-1.c: Likewise.
+	* gcc.dg/pr99122-2.c: Likewise.
+	* gcc.dg/pr99122-3.c: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.dg/Warray-bounds-51.c
+++ b/gcc/testsuite/gcc.dg/Warray-bounds-51.c
@@ -2,6 +2,7 @@
    PR middle-end/82608 - missing -Warray-bounds on an out-of-bounds VLA index
    { dg-do compile }
    { dg-options "-O2 -Wall" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void sink (void*);
 

--- a/gcc/testsuite/gcc.dg/Wrestrict-17.c
+++ b/gcc/testsuite/gcc.dg/Wrestrict-17.c
@@ -4,6 +4,7 @@
    { dg-require-effective-target alloca }
    { dg-options "-O2 -Wall" }  */
 /* { dg-additional-options "-Wno-implicit-function-declaration" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 int f (int n)
 {

--- a/gcc/testsuite/gcc.dg/Wstringop-overflow-39.c
+++ b/gcc/testsuite/gcc.dg/Wstringop-overflow-39.c
@@ -3,6 +3,7 @@
    { dg-do compile }
    { dg-options "-O2 -Wall" }
    { dg-require-effective-target alloca } */
+/* { dg-require-effective-target vla_in_struct } */
 
 extern void sink (void*);
 

--- a/gcc/testsuite/gcc.dg/builtin-clear-padding-1.c
+++ b/gcc/testsuite/gcc.dg/builtin-clear-padding-1.c
@@ -1,6 +1,8 @@
 /* PR libstdc++/88101 */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target-flag { -fuse-linker-plugin } } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void
 foo (int n)

--- a/gcc/testsuite/gcc.dg/pr51628-18.c
+++ b/gcc/testsuite/gcc.dg/pr51628-18.c
@@ -1,6 +1,7 @@
 /* PR c/51628.  */
 /* { dg-do compile } */
 /* { dg-options "-O" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void foo (int *);
 

--- a/gcc/testsuite/gcc.dg/pr51628-19.c
+++ b/gcc/testsuite/gcc.dg/pr51628-19.c
@@ -1,6 +1,7 @@
 /* PR c/51628.  */
 /* { dg-do compile } */
 /* { dg-options "-O" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void foo (int *);
 

--- a/gcc/testsuite/gcc.dg/pr93577-1.c
+++ b/gcc/testsuite/gcc.dg/pr93577-1.c
@@ -1,6 +1,7 @@
 /* Test ICE with variable-size struct initializer: bug 93577.  */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void
 f (int c)

--- a/gcc/testsuite/gcc.dg/pr93577-2.c
+++ b/gcc/testsuite/gcc.dg/pr93577-2.c
@@ -1,6 +1,7 @@
 /* Test ICE with variable-size struct initializer: bug 93577.  */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void
 f (int c)

--- a/gcc/testsuite/gcc.dg/pr93577-3.c
+++ b/gcc/testsuite/gcc.dg/pr93577-3.c
@@ -1,6 +1,7 @@
 /* Test ICE with variable-size struct initializer: bug 93577.  */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void
 f (int c)

--- a/gcc/testsuite/gcc.dg/pr93577-4.c
+++ b/gcc/testsuite/gcc.dg/pr93577-4.c
@@ -1,6 +1,7 @@
 /* Test ICE with variable-size struct initializer: bug 93577.  */
 /* { dg-do compile } */
 /* { dg-options "" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void
 f (int c)

--- a/gcc/testsuite/gcc.dg/pr99122-1.c
+++ b/gcc/testsuite/gcc.dg/pr99122-1.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -g -w" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 void f ()
 {

--- a/gcc/testsuite/gcc.dg/pr99122-2.c
+++ b/gcc/testsuite/gcc.dg/pr99122-2.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -g -w" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 static int foo ();
 

--- a/gcc/testsuite/gcc.dg/pr99122-3.c
+++ b/gcc/testsuite/gcc.dg/pr99122-3.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -g -w" } */
+/* { dg-require-effective-target vla_in_struct } */
 
 static int foo ();
 


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm

        * gcc.dg/Warray-bounds-51.c: Marked as requireing
        vla_in_struct support.
        * gcc.dg/Wrestrict-17.c: Likewise.
        * gcc.dg/Wstringop-overflow-39.c: Likewise.
        * gcc.dg/builtin-clear-padding-1.c: Likewise.
        * gcc.dg/pr51628-18.c: Likewise.
        * gcc.dg/pr51628-19.c: Likewise.
        * gcc.dg/pr93577-1.c: Likewise.
        * gcc.dg/pr93577-2.c: Likewise.
        * gcc.dg/pr93577-3.c: Likewise.
        * gcc.dg/pr93577-4.c: Likewise.
        * gcc.dg/pr99122-1.c: Likewise.
        * gcc.dg/pr99122-2.c: Likewise.
        * gcc.dg/pr99122-3.c: Likewise.