### PR TITLE
Mark test's that require appropriate flag/s

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,22 @@
+2021-05-11  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gcc/testsuite/gcc.dg/c2x-float-6.c: Likewise.: Mark as requiring appropriate flag/s.
+	* gcc/testsuite/gcc.dg/falign-labels-1.c: Likewise.
+	* gcc/testsuite/gcc.dg/iec-559-macros-6.c: Likewise.
+	* gcc/testsuite/gcc.dg/live-patching-3.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr44964.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr87979.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr88855.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr89570.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr91860-1.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr91860-2.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr92263.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr92430.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr94001.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr95854.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr97078.c: Likewise.
+	* gcc/testsuite/gcc.dg/sms-compare-debug-2.c: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.dg/c2x-float-6.c
+++ b/gcc/testsuite/gcc.dg/c2x-float-6.c
@@ -2,6 +2,7 @@
 /* { dg-do run } */
 /* { dg-options "-std=c2x -pedantic-errors -fsignaling-nans" } */
 /* { dg-add-options ieee } */
+/* { dg-require-effective-target-flag { -fsignaling-nans } } */
 
 #include <float.h>
 

--- a/gcc/testsuite/gcc.dg/falign-labels-1.c
+++ b/gcc/testsuite/gcc.dg/falign-labels-1.c
@@ -1,6 +1,7 @@
 /* { dg-do run } */
 /* { dg-options "-falign-labels=8" } */
 /* { dg-skip-if "no label alignment > 2" { "pdp11-*-*" } } */
+/* { dg-require-effective-target-flag { -falign-labels=8 } } */
 
 /* On ARMv7-A CPUs, this test resulted in incorrect code generation.
    The code generated for the switch statement expected the jump table

--- a/gcc/testsuite/gcc.dg/iec-559-macros-6.c
+++ b/gcc/testsuite/gcc.dg/iec-559-macros-6.c
@@ -1,6 +1,7 @@
 /* Test __GCC_IEC_559 and __GCC_IEC_559_COMPLEX macros values.  */
 /* { dg-do preprocess } */
 /* { dg-options "-fsingle-precision-constant" } */
+/* { dg-require-effective-target-flag { -fsingle-precision-constant } } */
 
 #ifndef __GCC_IEC_559
 # error "__GCC_IEC_559 not defined"

--- a/gcc/testsuite/gcc.dg/live-patching-3.c
+++ b/gcc/testsuite/gcc.dg/live-patching-3.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -flive-patching -fwhole-program" } */
+/* { dg-require-effective-target-flag { -flive-patching -fwhole-program } } */
 
 int main()
 {

--- a/gcc/testsuite/gcc.dg/pr44964.c
+++ b/gcc/testsuite/gcc.dg/pr44964.c
@@ -1,6 +1,7 @@
 /* { dg-do compile } */
 /* { dg-options "-fkeep-inline-functions -O" } */
 /* { dg-additional-options "-Wno-unused-value" } */
+/* { dg-require-effective-target-flag { -fkeep-inline-functions } } */
 
 static inline __attribute__ ((const))
 int baz (int i)

--- a/gcc/testsuite/gcc.dg/pr87979.c
+++ b/gcc/testsuite/gcc.dg/pr87979.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-options "-Os -fmodulo-sched -fno-tree-loop-im" } */
 /* { dg-additional-options "-march=z196" { target { s390*-*-* } } } */
+/* { dg-require-effective-target-flag { -fmodulo-sched -fno-tree-loop-im } } */
 
 void foo(void)
 {

--- a/gcc/testsuite/gcc.dg/pr88855.c
+++ b/gcc/testsuite/gcc.dg/pr88855.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O -ftree-loop-if-convert -ftree-vrp -fno-tree-copy-prop -fno-tree-dce -fno-tree-dominator-opts" } */
+/* { dg-require-effective-target-flag { -ftree-loop-if-convert -ftree-vrp -fno-tree-copy-prop -fno-tree-dce -fno-tree-dominator-opts } } */
 
 typedef int jmp_buf[1];
 

--- a/gcc/testsuite/gcc.dg/pr89570.c
+++ b/gcc/testsuite/gcc.dg/pr89570.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -ftree-vectorize -fno-trapping-math -fno-tree-dce -fno-tree-dominator-opts" } */
 /* { dg-additional-options "-mvsx" { target powerpc_vsx_ok } } */
+/* { dg-require-effective-target-flag { -ftree-vectorize -fno-trapping-math -fno-tree-dce -fno-tree-dominator-opts } } */
 
 void
 foo (double *x, double *y, double *z)

--- a/gcc/testsuite/gcc.dg/pr91860-1.c
+++ b/gcc/testsuite/gcc.dg/pr91860-1.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-Og -fipa-cp -g --param=max-combine-insns=3" } */
+/* { dg-require-effective-target-flag { -fipa-cp } } */
 
 char a;
 int b;

--- a/gcc/testsuite/gcc.dg/pr91860-2.c
+++ b/gcc/testsuite/gcc.dg/pr91860-2.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-Og -fexpensive-optimizations -fno-tree-fre -g --param=max-combine-insns=4" } */
+/* { dg-require-effective-target-flag { -fexpensive-optimizations -fno-tree-fre } } */
 
 unsigned a, b, c;
 void

--- a/gcc/testsuite/gcc.dg/pr92263.c
+++ b/gcc/testsuite/gcc.dg/pr92263.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-fno-tree-dce -fno-tree-forwprop -Os -ffloat-store" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce -fno-tree-forwprop -ffloat-store } } */
 
 extern long double cabsl (_Complex long double);
 

--- a/gcc/testsuite/gcc.dg/pr92430.c
+++ b/gcc/testsuite/gcc.dg/pr92430.c
@@ -1,6 +1,7 @@
 // PR rtl-optimization/92430
 // { dg-do compile }
 // { dg-options "-Os -fno-if-conversion -fno-tree-dce -fno-tree-loop-optimize -fno-tree-vrp" }
+/* { dg-require-effective-target-flag { -fno-if-conversion -fno-tree-dce -fno-tree-loop-optimize -fno-tree-vrp } } */
 
 int eb, ko;
 

--- a/gcc/testsuite/gcc.dg/pr94001.c
+++ b/gcc/testsuite/gcc.dg/pr94001.c
@@ -1,6 +1,7 @@
 /* PR tree-optimization/94001 */
 /* { dg-do compile } */
 /* { dg-options "-O2 -fno-tree-dce" } */
+/* { dg-require-effective-target-flag { -fno-tree-dce } } */
 
 void
 bar (int e)

--- a/gcc/testsuite/gcc.dg/pr95854.c
+++ b/gcc/testsuite/gcc.dg/pr95854.c
@@ -1,6 +1,7 @@
 /* { dg-do compile } */
 /* { dg-options "-O3 -fno-vect-cost-model -fno-tree-scev-cprop -ftracer" } */
 /* { dg-additional-options "-march=armv8.5-a+sve2" { target aarch64*-*-* } } */
+/* { dg-require-effective-target-flag { -fno-vect-cost-model -fno-tree-scev-cprop -ftracer } } */
 
 extern void abort (void);
 int c, d;

--- a/gcc/testsuite/gcc.dg/pr97078.c
+++ b/gcc/testsuite/gcc.dg/pr97078.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -ffloat-store" } */
+/* { dg-require-effective-target-flag { -ffloat-store } } */
 
 extern void foo (long double);
 

--- a/gcc/testsuite/gcc.dg/sms-compare-debug-2.c
+++ b/gcc/testsuite/gcc.dg/sms-compare-debug-2.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -fcompare-debug -fmodulo-sched" } */
+/* { dg-require-effective-target-flag { -fcompare-debug -fmodulo-sched } } */
 
 struct S { int f; signed int g : 2; } a[1], c = {5, 1}, d;
 short b;

--- a/gcc/testsuite/lib/target-supports-dg.exp
+++ b/gcc/testsuite/lib/target-supports-dg.exp
@@ -243,6 +243,37 @@ proc dg-require-effective-target { args } {
     }
 }
 
+# If the target does not support the specified flag, skip this test.
+# Only apply this if the optional selector matches.
+# args[0] flag to test for
+# args[1] optional selector
+
+proc dg-require-effective-target-flag { args } {
+    set args [lreplace $args 0 0]
+    # Verify the number of arguments.  The last is optional.
+    if { [llength $args] < 1 || [llength $args] > 2 } {
+    error "syntax error, need a single effective-target flag with optional selector"
+    }
+
+    # Don't bother if we're already skipping the test.
+    upvar dg-do-what dg-do-what
+    if { [lindex ${dg-do-what} 1] == "N" } {
+      return
+    }
+
+    # Evaluate selector if present.
+    if { [llength $args] == 2 } {
+    switch [dg-process-target-1 [lindex $args 1]] {
+        "S" { }
+        "N" { return }
+    }
+    }
+
+    if { ![is-effective-target-flag [lindex $args 0]] } {
+        set dg-do-what [list [lindex ${dg-do-what} 0] "N" "P"]
+    }
+}
+
 # If this target does not have fork, skip this test.
 
 proc dg-require-fork { args } {

--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -8179,6 +8179,27 @@ proc is-effective-target { arg } {
     return $selected
 }
 
+# Return 1 if the effective target supports the specified flag
+# This can be used with any check_flag_* proc that takes no argument and
+# returns only 1 or 0.
+# arg[0] the flag to check for.
+
+proc is-effective-target-flag { arg } {
+    set selected 0
+
+    set selected [check_no_compiler_messages optimisation_flag assembly "
+        int main (void) { return 0; }
+    " "$arg"]
+    if { !$selected } {
+      return 0
+    } else {
+      return 1
+    }
+
+    verbose "is-effective-target-flag: $arg $selected" 2
+    return selected
+}
+
 # Return 1 if the argument is an effective-target keyword, 0 otherwise.
 
 proc is-effective-target-keyword { arg } {
@@ -11402,4 +11423,3 @@ proc check_effective_target_invalid_inline_asm { } {
 	void foo (void) { asm ("This is invalid"); }
     }]
 }
-


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

	* gcc/testsuite/gcc.dg/c2x-float-6.c: Likewise.: Mark as requiring appropriate flag/s.
	* gcc/testsuite/gcc.dg/falign-labels-1.c: Likewise.
	* gcc/testsuite/gcc.dg/iec-559-macros-6.c: Likewise.
	* gcc/testsuite/gcc.dg/live-patching-3.c: Likewise.
	* gcc/testsuite/gcc.dg/pr44964.c: Likewise.
	* gcc/testsuite/gcc.dg/pr87979.c: Likewise.
	* gcc/testsuite/gcc.dg/pr88855.c: Likewise.
	* gcc/testsuite/gcc.dg/pr89570.c: Likewise.
	* gcc/testsuite/gcc.dg/pr91860-1.c: Likewise.
	* gcc/testsuite/gcc.dg/pr91860-2.c: Likewise.
	* gcc/testsuite/gcc.dg/pr92263.c: Likewise.
	* gcc/testsuite/gcc.dg/pr92430.c: Likewise.
	* gcc/testsuite/gcc.dg/pr94001.c: Likewise.
	* gcc/testsuite/gcc.dg/pr95854.c: Likewise.
	* gcc/testsuite/gcc.dg/pr97078.c: Likewise.
	* gcc/testsuite/gcc.dg/sms-compare-debug-2.c: Likewise.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>