### PR TITLE
Mark tests as requiring setjmp/longjmp builtins

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,10 @@
+2021-05-11  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gcc.c-torture/compile/pr89280.c: Mark test as requiring setjmp/longjmp builtins.
+	* gcc.c-torture/execute/pr64242.c: Likewise.
+	* gcc.c-torture/execute/pr84521.c: Likewise.
+	* gcc.dg/pr90082.c: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.c-torture/compile/pr89280.c
+++ b/gcc/testsuite/gcc.c-torture/compile/pr89280.c
@@ -1,5 +1,6 @@
 // { dg-require-effective-target nonlocal_goto }
 // { dg-require-effective-target label_values }
+// { dg-require-effective-target builtin_setjmp_longjmp }
 /* PR tree-optimization/89280 */
 
 int a;

--- a/gcc/testsuite/gcc.c-torture/execute/pr64242.c
+++ b/gcc/testsuite/gcc.c-torture/execute/pr64242.c
@@ -1,4 +1,5 @@
 /* { dg-require-effective-target indirect_jumps } */
+/* { dg-require-effective-target builtin_setjmp_longjmp } */
 
 extern void abort (void);
 

--- a/gcc/testsuite/gcc.c-torture/execute/pr84521.c
+++ b/gcc/testsuite/gcc.c-torture/execute/pr84521.c
@@ -1,4 +1,5 @@
 /* { dg-require-effective-target indirect_jumps } */
+/* { dg-require-effective-target builtin_setjmp_longjmp } */
 /* { dg-additional-options "-fomit-frame-pointer -fno-inline" }  */
 
 extern void abort (void);

--- a/gcc/testsuite/gcc.dg/pr90082.c
+++ b/gcc/testsuite/gcc.dg/pr90082.c
@@ -2,6 +2,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target nonlocal_goto } */
 /* { dg-require-effective-target label_values } */
+/* { dg-require-effective-target builtin_setjmp_longjmp } */
 /* { dg-options "-O1 -fnon-call-exceptions -ftrapv" } */
 
 void *buf[5];


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

	* gcc.c-torture/compile/pr89280.c: Mark test as requiring setjmp/longjmp builtins.
	* gcc.c-torture/execute/pr64242.c: Likewise.
	* gcc.c-torture/execute/pr84521.c: Likewise.
	* gcc.dg/pr90082.c: Likewise.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>