### PR TITLE
Fixed *.exp file errors

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,13 @@
+2021-05-11  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* gcc.dg/graphite/graphite.exp: Replaced dg-require-effective-target
+	gcc_frontend with check_effective_target_gcc_frontend.
+	* gcc.dg/rtl/rtl.exp: Likewise.
+	* gcc.dg/vect/costmodel/i386/i386-costmodel-vect.exp: Likewise.
+	* gcc.dg/vect/costmodel/ppc/ppc-costmodel-vect.exp: Likewise.
+	* gcc.dg/vect/costmodel/x86_64/x86_64-costmodel-vect.exp: Likewise.
+	* gcc.dg/vect/vect.exp: Likewise.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.dg/graphite/graphite.exp
+++ b/gcc/testsuite/gcc.dg/graphite/graphite.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 #   Copyright (C) 2006-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -21,6 +20,10 @@
 load_lib gcc-dg.exp
 
 if ![check_effective_target_fgraphite] {
+  return
+}
+
+if { ![check_effective_target_gcc_frontend] } {
   return
 }
 

--- a/gcc/testsuite/gcc.dg/rtl/rtl.exp
+++ b/gcc/testsuite/gcc.dg/rtl/rtl.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 #   Copyright (C) 2016-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -19,6 +18,10 @@
 
 # Load support procs.
 load_lib gcc-dg.exp
+
+if { ![check_effective_target_gcc_frontend] } {
+  return
+}
 
 # If a testcase doesn't have special options, use these.
 global DEFAULT_RTLFLAGS

--- a/gcc/testsuite/gcc.dg/vect/costmodel/i386/i386-costmodel-vect.exp
+++ b/gcc/testsuite/gcc.dg/vect/costmodel/i386/i386-costmodel-vect.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 # Copyright (C) 1997-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -22,6 +21,10 @@ load_lib gcc-dg.exp
 
 # Exit immediately if this isn't a x86 target.
 if { ![istarget i?86*-*-*] && ![istarget x86_64-*-*] } then {
+  return
+}
+
+if { ![check_effective_target_gcc_frontend] } {
   return
 }
 

--- a/gcc/testsuite/gcc.dg/vect/costmodel/ppc/ppc-costmodel-vect.exp
+++ b/gcc/testsuite/gcc.dg/vect/costmodel/ppc/ppc-costmodel-vect.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 # Copyright (C) 1997-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -27,6 +26,10 @@ if { ![istarget powerpc*-*-*] } then {
 
 # Skip targets not supporting -maltivec.
 if ![is-effective-target powerpc_altivec_ok] {
+  return
+}
+
+if { ![check_effective_target_gcc_frontend] } {
   return
 }
 

--- a/gcc/testsuite/gcc.dg/vect/costmodel/x86_64/x86_64-costmodel-vect.exp
+++ b/gcc/testsuite/gcc.dg/vect/costmodel/x86_64/x86_64-costmodel-vect.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 # Copyright (C) 1997-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -23,6 +22,10 @@ load_lib gcc-dg.exp
 # Exit immediately if this isn't a x86 target.
 if { (![istarget x86_64-*-*] && ![istarget i?86-*-*])
      || [is-effective-target ia32] } then {
+  return
+}
+
+if { ![check_effective_target_gcc_frontend] } {
   return
 }
 

--- a/gcc/testsuite/gcc.dg/vect/vect.exp
+++ b/gcc/testsuite/gcc.dg/vect/vect.exp
@@ -1,4 +1,3 @@
-/* { dg-require-effective-target gcc_frontend } */
 # Copyright (C) 1997-2021 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
@@ -43,6 +42,10 @@ set save-dg-do-what-default ${dg-do-what-default}
 # overridden by using dg-options in individual tests.
 if ![check_vect_support_and_set_flags] {
     return
+}
+
+if { ![check_effective_target_gcc_frontend] } {
+  return
 }
 
 # These flags are used for all targets.


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

        * gcc.dg/graphite/graphite.exp: Replaced dg-require-effective-target
        gcc_frontend with check_effective_target_gcc_frontend.
        * gcc.dg/rtl/rtl.exp: Likewise.
        * gcc.dg/vect/costmodel/i386/i386-costmodel-vect.exp: Likewise.
        * gcc.dg/vect/costmodel/ppc/ppc-costmodel-vect.exp: Likewise.
        * gcc.dg/vect/costmodel/x86_64/x86_64-costmodel-vect.exp: Likewise.
        * gcc.dg/vect/vect.exp: Likewise.