### PR TITLE
Mark tests that requires gcc front end for inline asm

### DIFF
--- a/gcc/testsuite/ChangeLog.Embecosm
+++ b/gcc/testsuite/ChangeLog.Embecosm
@@ -1,3 +1,8 @@
+2021-05-13  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gcc.c-torture/compile/920520-1.c: Mark as requiring gcc frontend as
+	tests assumes GCC parsing behaviour.
+
 2020-09-25  Lewis Revill <lewis.revill@embecosm.com>
 
 	* gcc.dg/addr_equal-1.c: Add -Wno-ignored-optimization-argument to

--- a/gcc/testsuite/gcc.c-torture/compile/920520-1.c
+++ b/gcc/testsuite/gcc.c-torture/compile/920520-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
 /* { dg-skip-if "" { pdp11-*-* } } */
+/* { dg-require-effective-target gcc_frontend } */
 
 f(){asm("%0"::"r"(1.5F));}g(){asm("%0"::"r"(1.5));}


### PR DESCRIPTION
gcc/testsuite/ChangeLog.Embecosm:

        * gcc.c-torture/compile/920520-1.c: Mark as requiring gcc frontend as
        tests assumes GCC parsing behaviour.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>